### PR TITLE
package.json: fix missing deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,28 +25,30 @@
     "url": "https://github.com/requireio/style-deps/issues"
   },
   "dependencies": {
-    "flatten": "0.0.1",
-    "async-series": "0.0.1",
-    "map-async": "~0.1.1",
-    "graceful-fs": "~2.0.1",
-    "convert-source-map": "~0.3.3",
-    "multipipe": "0.0.1",
-    "css": "~1.6.0",
-    "stream-browserify": "~0.1.3",
-    "bl": "~0.7.0",
-    "resolve": "0.6.1",
-    "xtend": "^2.1.2",
-    "findup": "~0.1.3",
     "ast-pipeline": "~0.1.0",
-    "new-from": "0.0.3",
-    "shallow-copy": "0.0.1",
+    "async-series": "0.0.1",
+    "bl": "~0.7.0",
+    "convert-source-map": "~0.3.3",
+    "css": "~1.6.0",
     "duplexer2": "0.0.1",
+    "findup": "~0.1.3",
+    "flatten": "0.0.1",
+    "graceful-fs": "~2.0.1",
+    "map-async": "~0.1.1",
+    "multipipe": "0.0.1",
+    "new-from": "0.0.3",
+    "once": "^1.3.1",
+    "resolve": "0.6.1",
+    "shallow-copy": "0.0.1",
+    "stream-browserify": "~0.1.3",
+    "style-resolve": "0.0.0",
     "through2": "~0.4.1",
-    "style-resolve": "0.0.0"
+    "xtend": "^2.1.2"
   },
   "devDependencies": {
     "tape": "^2.4.2",
     "rework": "~0.20.2",
-    "rework-variables": "0.0.8"
+    "rework-variables": "0.0.8",
+    "through": "^2.3.6"
   }
 }


### PR DESCRIPTION
This adds the `once` and `through` packages which were missing from the `package.json`. It also (unintentionally) changes the order in which dependencies are listen, which `npm` does automatically on install. I hope this is helpful. Thanks!
