### PR TITLE
package.json: update `css` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "graceful-fs": "~2.0.1",
     "convert-source-map": "~0.3.3",
     "multipipe": "0.0.1",
-    "css": "~1.6.0",
+    "css": "~2.0.0",
     "stream-browserify": "~0.1.3",
     "bl": "~0.7.0",
     "resolve": "0.6.1",


### PR DESCRIPTION
Changes the `css` version to 2.0.0. Adds support for `@font-face`, `@host` and `@custom-media`. A full list of the 2.0.0 changes is available [here](https://github.com/reworkcss/css/blob/master/History.md#200--2014-06-18). Thanks!
